### PR TITLE
Replace per-field buffer with a bufio.Writer

### DIFF
--- a/passthrough_test.go
+++ b/passthrough_test.go
@@ -23,6 +23,11 @@ func TestWriterToReader(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		err = w.Flush()
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		r := NewReader(strings.NewReader(b.String()))
 		records, err := r.ReadAll()
 		if err != io.EOF {
@@ -65,6 +70,11 @@ func TestReaderToWriter(t *testing.T) {
 		w := NewWriter(&b)
 
 		err = w.WriteAll(records)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = w.Flush()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/stubs_test.go
+++ b/stubs_test.go
@@ -10,8 +10,22 @@ func (r readerStub) Read(b []byte) (int, error) {
 	return 0, stubError
 }
 
-type writerStub struct{}
+type writerStub struct {
+	errorCountdown int
+}
 
-func (r writerStub) Write(b []byte) (int, error) {
-	return 0, stubError
+func (r *writerStub) Write(b []byte) (int, error) {
+	r.errorCountdown -= len(b)
+	if r.errorCountdown <= 0 {
+		return 0, stubError
+	}
+
+	return len(b), nil
+}
+
+func (r *writerStub) Flush() error {
+	if r.errorCountdown <= 0 {
+		return stubError
+	}
+	return nil
 }

--- a/stubs_test.go
+++ b/stubs_test.go
@@ -10,22 +10,12 @@ func (r readerStub) Read(b []byte) (int, error) {
 	return 0, stubError
 }
 
-type writerStub struct {
-	errorCountdown int
+type writerStub struct{}
+
+func (r writerStub) Write(b []byte) (int, error) {
+	return 0, stubError
 }
 
-func (r *writerStub) Write(b []byte) (int, error) {
-	r.errorCountdown -= len(b)
-	if r.errorCountdown <= 0 {
-		return 0, stubError
-	}
-
-	return len(b), nil
-}
-
-func (r *writerStub) Flush() error {
-	if r.errorCountdown <= 0 {
-		return stubError
-	}
-	return nil
+func (r writerStub) Flush() error {
+	return stubError
 }

--- a/writer.go
+++ b/writer.go
@@ -7,10 +7,7 @@ import (
 
 // Writer can be used to write CSV formatted data to an io.Writer
 type Writer struct {
-	w interface {
-		Write([]byte) (int, error)
-		Flush() error
-	}
+	w *bufio.Writer
 }
 
 // NewWriter returns a writer ready to write CSV formatted data to the destination

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,6 +1,7 @@
 package csv
 
 import (
+	"bufio"
 	"strings"
 	"testing"
 )
@@ -57,11 +58,11 @@ func TestWriteAllErrorPassthrough(t *testing.T) {
 }
 
 func TestWriteAllBufferErrorPassthrough(t *testing.T) {
-	for i := 0; i < 5; i++ {
-		w := NewWriter(&writerStub{})
+	for i := 1; i < 5; i++ {
+		w := NewWriter(writerStub{})
 
-		// Replace the internal bufio buffer with a stub that fails after i "written" bytes
-		w.w = &writerStub{errorCountdown: i}
+		// Replace the internal bufio buffer to trigger the writerStub error after i bytes written
+		w.w = bufio.NewWriterSize(writerStub{}, i)
 
 		err := w.WriteAll([][]string{{`a`, `b`}})
 		if err != stubError {

--- a/writer_test.go
+++ b/writer_test.go
@@ -32,6 +32,11 @@ func TestWriteAll(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		err = w.Flush()
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		if b.String() != cases[i].output {
 			t.Fatalf("case %v expected output %#v, got %#v", i, cases[i].output, b.String())
 		}
@@ -39,10 +44,28 @@ func TestWriteAll(t *testing.T) {
 }
 
 func TestWriteAllErrorPassthrough(t *testing.T) {
-	w := NewWriter(writerStub{})
+	w := NewWriter(&writerStub{})
 	err := w.WriteAll([][]string{{""}})
+
+	if err == nil {
+		err = w.Flush()
+	}
 
 	if err != stubError {
 		t.Fatalf("expected %v got %v", stubError, err)
+	}
+}
+
+func TestWriteAllBufferErrorPassthrough(t *testing.T) {
+	for i := 0; i < 5; i++ {
+		w := NewWriter(&writerStub{})
+
+		// Replace the internal bufio buffer with a stub that fails after i "written" bytes
+		w.w = &writerStub{errorCountdown: i}
+
+		err := w.WriteAll([][]string{{`a`, `b`}})
+		if err != stubError {
+			t.Fatalf("case with internal buffer length %v expected %v got %v", i, stubError, err)
+		}
 	}
 }


### PR DESCRIPTION
This makes us buffer more, sparing the destination writer some mini-writes.

It also pulls our interface closer to that of the `encoding/csv` package.